### PR TITLE
feat: add `SetPrompt` method to `Context` interface and structs

### DIFF
--- a/bindings/go/examples/go-whisper/process.go
+++ b/bindings/go/examples/go-whisper/process.go
@@ -67,7 +67,7 @@ func Process(model whisper.Model, path string, flags *Flags) error {
 	// Process the data
 	fmt.Fprintf(flags.Output(), "  ...processing %q\n", path)
 	context.ResetTimings()
-	if err := context.Process(data, cb); err != nil {
+	if err := context.Process(data, cb, nil); err != nil {
 		return err
 	}
 

--- a/bindings/go/params.go
+++ b/bindings/go/params.go
@@ -114,6 +114,11 @@ func (p *Params) SetMaxTokensPerSegment(n int) {
 	p.max_tokens = C.int(n)
 }
 
+// Set max tokens per segment (0 = no limit)
+func (p *Params) SetPrompt(v string) {
+	p.initial_prompt = C.CString(v)
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // PRIVATE METHODS
 
@@ -164,6 +169,10 @@ func (p *Params) String() string {
 	if p.speed_up {
 		str += " speed_up"
 	}
+	if p.initial_prompt != nil {
+		str += fmt.Sprintf(" initial_prompt=%s", p.initial_prompt)
+	}
+
 
 	return str + ">"
 }

--- a/bindings/go/params.go
+++ b/bindings/go/params.go
@@ -173,6 +173,5 @@ func (p *Params) String() string {
 		str += fmt.Sprintf(" initial_prompt=%s", p.initial_prompt)
 	}
 
-
 	return str + ">"
 }

--- a/bindings/go/params.go
+++ b/bindings/go/params.go
@@ -114,7 +114,8 @@ func (p *Params) SetMaxTokensPerSegment(n int) {
 	p.max_tokens = C.int(n)
 }
 
-// Set max tokens per segment (0 = no limit)
+// SetPrompt sets the initial prompt for the whisper session.
+// The prompt is a string that provides some context for the speech recognition.
 func (p *Params) SetPrompt(v string) {
 	p.initial_prompt = C.CString(v)
 }

--- a/bindings/go/pkg/whisper/context.go
+++ b/bindings/go/pkg/whisper/context.go
@@ -145,6 +145,11 @@ func (context *context) SystemInfo() string {
 	)
 }
 
+// SetPrompt
+func (context *context) SetPrompt(v string) {
+	context.params.SetPrompt(v)
+}
+
 // Use mel data at offset_ms to try and auto-detect the spoken language
 // Make sure to call whisper_pcm_to_mel() or whisper_set_mel() first.
 // Returns the probabilities of all languages.

--- a/bindings/go/pkg/whisper/interface.go
+++ b/bindings/go/pkg/whisper/interface.go
@@ -48,6 +48,7 @@ type Context interface {
 	SetTokenTimestamps(bool)      // Set token timestamps flag
 	SetMaxTokensPerSegment(uint)  // Set max tokens per segment (0 = no limit)
 	SetPrintProgress(bool)        // Set print progress flag
+	SetPrompt(string) // Set prompt 
 
 	// Process mono audio data and return any errors.
 	// If defined, newly generated segments are passed to the

--- a/bindings/go/pkg/whisper/interface.go
+++ b/bindings/go/pkg/whisper/interface.go
@@ -48,7 +48,7 @@ type Context interface {
 	SetTokenTimestamps(bool)      // Set token timestamps flag
 	SetMaxTokensPerSegment(uint)  // Set max tokens per segment (0 = no limit)
 	SetPrintProgress(bool)        // Set print progress flag
-	SetPrompt(string)             // Set prompt 
+	SetPrompt(string)             // Set prompt
 
 	// Process mono audio data and return any errors.
 	// If defined, newly generated segments are passed to the

--- a/bindings/go/pkg/whisper/interface.go
+++ b/bindings/go/pkg/whisper/interface.go
@@ -48,7 +48,7 @@ type Context interface {
 	SetTokenTimestamps(bool)      // Set token timestamps flag
 	SetMaxTokensPerSegment(uint)  // Set max tokens per segment (0 = no limit)
 	SetPrintProgress(bool)        // Set print progress flag
-	SetPrompt(string) // Set prompt 
+	SetPrompt(string)             // Set prompt 
 
 	// Process mono audio data and return any errors.
 	// If defined, newly generated segments are passed to the


### PR DESCRIPTION
- Add a `SetPrompt` method to the `Params` struct in `bindings/go/params.go`
- Add a `SetPrompt` method to the `context` struct in `bindings/go/pkg/whisper/context.go`
- Add a `SetPrompt` method to the `Context` interface in `bindings/go/pkg/whisper/interface.go`
- Modify the `Process` function in `bindings/go/examples/go-whisper/process.go` to include an additional argument in the `context.Process` call